### PR TITLE
Support for Babel 7

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -79,10 +79,6 @@ const createTransformer = (options) => {
                 babel = require('babel-core');
             }
 
-            if (!babel.util.canCompile(filename)) {
-                return src;
-            }
-
             const theseOptions = Object.assign({filename}, options);
 
             if (transformOptions && transformOptions.instrument) {


### PR DESCRIPTION
Babel 7 doesn't contain util anymore, therefore transformation of all files fails.

There doesn't seem to be any need to check canCompile first, so the check gets removed.